### PR TITLE
chore: Update 7 dependencies with Dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.682.0.tgz",
-      "integrity": "sha512-BD8PPPk3+ZzFqCJSPraoXkgRcPTtjguXtyDYsyBMzFofWmN4YeswXSavZVAC354W98mkffDaXBvieyqu1Y9fKA==",
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.685.0.tgz",
+      "integrity": "sha512-4h+aw0pUEOVP77TpF1ec9AX0mzotsiw2alXfh+P0t+43eg2EjaKRftRpNXyt5XmUPws+wsH10uEL4CzSZo1sxQ==",
       "optional": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -386,12 +386,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.682.0.tgz",
-      "integrity": "sha512-V+y4qUQtc0kTnNR7u5LwnZn8EZk2pjdNX+84MwD9VjXekqbXikADu06Mj93kVGVW+qgqtNMvJ8PpiI3EaaxC7A==",
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.685.0.tgz",
+      "integrity": "sha512-qw9s09JFhJxEkmbo1gn94pAtyLHSx8YBX2qqrL6v3BdsJbP2fnRJMMssGMGR4jPyhklh5TSgZo0FzflbqJU8sw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.682.0",
+        "@aws-sdk/client-cognito-identity": "3.685.0",
         "@aws-sdk/types": "3.679.0",
         "@smithy/property-provider": "^3.1.7",
         "@smithy/types": "^3.5.0",
@@ -543,16 +543,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.682.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.682.0.tgz",
-      "integrity": "sha512-vLBdUlTISEXVKYFFO665ajC0U0RdXFx21fwTHiN2g4edFH++di2XCJ8/Y34bu09z9bV/rwFT2jn41iAVWasNKg==",
+      "version": "3.685.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.685.0.tgz",
+      "integrity": "sha512-pIXNNwPG2KnzjGYYbADquEkROuKxAJxuWt87TJO7LCFqKwb5l6h0Mc7yc4j13zxOVd/EhXD0VsPeqnobDklUoQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.682.0",
+        "@aws-sdk/client-cognito-identity": "3.685.0",
         "@aws-sdk/client-sso": "3.682.0",
         "@aws-sdk/client-sts": "3.682.0",
         "@aws-sdk/core": "3.679.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.682.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.685.0",
         "@aws-sdk/credential-provider-env": "3.679.0",
         "@aws-sdk/credential-provider-http": "3.679.0",
         "@aws-sdk/credential-provider-ini": "3.682.0",
@@ -3947,9 +3947,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.8.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.5.tgz",
-      "integrity": "sha512-5iYk6AMPtsMbkZqCO1UGF9W5L38twq11S2pYWkybGHH2ogPUvXWNlQqJBzuEZWKj/WRH+QTeiv6ySWqJtvIEgA==",
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
       "dependencies": {
         "undici-types": "~6.19.8"
       }
@@ -5866,9 +5866,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001676",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001676.tgz",
-      "integrity": "sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==",
+      "version": "1.0.30001677",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
+      "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
       "funding": [
         {
           "type": "opencollective",
@@ -7338,9 +7338,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.49",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.49.tgz",
-      "integrity": "sha512-ZXfs1Of8fDb6z7WEYZjXpgIRF6MEu8JdeGA0A40aZq6OQbS+eJpnnV49epZRna2DU/YsEjSQuGtQPPtvt6J65A=="
+      "version": "1.5.51",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.51.tgz",
+      "integrity": "sha512-kKeWV57KSS8jH4alKt/jKnvHPmJgBxXzGUSbMd4eQF+iOsVPl7bz2KUmu6eo80eMP8wVioTfTyTzdMgM15WXNg=="
     },
     "node_modules/elliptic": {
       "version": "6.6.0",
@@ -17419,9 +17419,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "optional": true
     },
     "node_modules/tsutils": {


### PR DESCRIPTION
-chore: Bump electron-to-chromium from 1.5.49 to 1.5.50 (#396)
-chore: Bump @types/node from 22.8.5 to 22.8.6 (#397)
-chore: Bump @aws-sdk/credential-providers from 3.682.0 to 3.685.0 (#398)
-chore: Bump @types/node from 22.8.6 to 22.8.7 (#399)
-chore: Bump caniuse-lite from 1.0.30001676 to 1.0.30001677 (#400)
-chore: Bump @types/node from 22.8.7 to 22.9.0 (#401)
-chore: Bump electron-to-chromium from 1.5.50 to 1.5.51 (#402)